### PR TITLE
PR #2: CI plumbing (GHCR + Doppler) and Docker healthchecks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Root dockerignore to keep build contexts small
+
+# VCS
+.git
+
+# Node
+node_modules/
+**/node_modules/
+**/*.tsbuildinfo
+apps/client/.next/
+
+# Python
+__pycache__/
+**/__pycache__/
+.venv/
+.venv-oracle/
+
+# Build outputs
+apps/core-service/dist/
+apps/core-service/coverage/
+apps/core-service/.env
+apps/core-service/prisma/*.db
+
+# Tests and local artifacts
+apps/core-service/test/
+apps/oracle-service/tests/

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,78 @@
+name: Docker Publish (GHCR)
+
+on:
+  push:
+    branches: [ main ]
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tags
+        id: meta
+        run: |
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          SHA=${{ github.sha }}
+          echo "core=ghcr.io/${OWNER}/core-service:${SHA}" >> $GITHUB_OUTPUT
+          echo "core_latest=ghcr.io/${OWNER}/core-service:latest" >> $GITHUB_OUTPUT
+          echo "oracle=ghcr.io/${OWNER}/oracle-service:${SHA}" >> $GITHUB_OUTPUT
+          echo "oracle_latest=ghcr.io/${OWNER}/oracle-service:latest" >> $GITHUB_OUTPUT
+
+      - name: Build & Push core-service
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/core-service/Dockerfile
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.core }}
+            ${{ steps.meta.outputs.core_latest }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build & Push oracle-service
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/oracle-service/Dockerfile
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.oracle }}
+            ${{ steps.meta.outputs.oracle_latest }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: (Optional) Install Doppler CLI
+        if: ${{ secrets.DOPPLER_TOKEN != '' }}
+        uses: dopplerhq/cli-action@v2
+
+      - name: (Optional) Verify Doppler connectivity
+        if: ${{ secrets.DOPPLER_TOKEN != '' }}
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+        run: |
+          doppler --version
+          doppler secrets download --no-file --format env --project ${{ vars.DOPPLER_PROJECT || 'studyapp' }} --config ${{ vars.DOPPLER_CONFIG || 'prod' }} >/dev/null

--- a/apps/core-service/Dockerfile
+++ b/apps/core-service/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1.7
+# Multi-stage build for core-service (NestJS)
+
+FROM node:22-alpine AS base
+RUN corepack enable && corepack prepare pnpm@10.15.1 --activate
+WORKDIR /app
+
+# Install deps (workspace-aware) with only the manifests first for better caching
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY apps/core-service/package.json apps/core-service/
+COPY packages/shared-types/package.json packages/shared-types/
+RUN pnpm -w install --frozen-lockfile
+
+# Build
+COPY . .
+RUN pnpm -w build
+
+# --- Runtime image ---
+FROM node:22-alpine AS runtime
+ENV NODE_ENV=production
+WORKDIR /app
+
+# copy node_modules from builder to avoid re-resolving workspace at runtime
+COPY --from=base /app/node_modules ./node_modules
+# copy built app
+COPY --from=base /app/apps/core-service/dist ./dist
+# minimal package.json for metadata (not used by runtime)
+COPY apps/core-service/package.json ./package.json
+
+EXPOSE 3000
+HEALTHCHECK --interval=10s --timeout=3s --retries=3 CMD wget -qO- http://localhost:3000/health/live || exit 1
+CMD ["node", "dist/main.js"]

--- a/apps/docker-compose.prod.yml
+++ b/apps/docker-compose.prod.yml
@@ -1,0 +1,118 @@
+version: "3.9"
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: studyapp
+      POSTGRES_USER: studyapp
+      POSTGRES_PASSWORD: studyapp
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U studyapp"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  rabbitmq:
+    image: rabbitmq:3-management-alpine
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "status"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  minio:
+    image: quay.io/minio/minio:latest
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  minio-mc:
+    image: minio/mc:latest
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: ["/bin/sh", "-c"]
+    command: >
+      "mc alias set local http://minio:9000 minioadmin minioadmin &&
+      mc mb -p local/studyapp-docs || true &&
+      mc anonymous set download local/studyapp-docs || true"
+
+  core-service:
+    image: ghcr.io/${GHCR_OWNER:-your-org}/core-service:latest
+    depends_on:
+      postgres:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    environment:
+      # Prisma (production uses Postgres)
+      DATABASE_URL: postgres://studyapp:studyapp@postgres:5432/studyapp
+      # Auth & internal
+      JWT_SECRET: ${JWT_SECRET:-dev-secret}
+      INTERNAL_API_KEY: ${INTERNAL_API_KEY:-dev-internal-key}
+      # RabbitMQ
+      RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672
+      # S3 / MinIO
+      AWS_REGION: us-east-1
+      AWS_S3_BUCKET: studyapp-docs
+      AWS_S3_ENDPOINT: http://minio:9000
+      AWS_S3_FORCE_PATH_STYLE: "true"
+    ports:
+      - "3000:3000"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/health/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  oracle-service:
+    image: ghcr.io/${GHCR_OWNER:-your-org}/oracle-service:latest
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+      core-service:
+        condition: service_started
+    environment:
+      RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672//
+      RABBITMQ_QUEUE_NAME: document_processing_jobs
+      CORE_SERVICE_URL: http://core-service:3000
+      INTERNAL_API_KEY: ${INTERNAL_API_KEY:-dev-internal-key}
+      AWS_REGION: us-east-1
+      S3_BUCKET: studyapp-docs
+      AWS_S3_ENDPOINT: http://minio:9000
+      AWS_S3_FORCE_PATH_STYLE: "true"
+      ENGINE_VERSION: oracle-v1
+    ports:
+      - "8081:8081"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8081/health/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  pgdata:
+  minio-data:

--- a/apps/oracle-service/Dockerfile
+++ b/apps/oracle-service/Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1.7
+# Multi-stage build for oracle-service (Python)
+
+FROM python:3.12-slim AS base
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+WORKDIR /app
+
+# System deps for science libs (minimal)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python deps
+COPY apps/oracle-service/requirements.txt apps/oracle-service/requirements.txt
+RUN pip install --no-cache-dir -r apps/oracle-service/requirements.txt
+
+# Copy project
+COPY . .
+
+# Default command launches the health server
+EXPOSE 8081
+HEALTHCHECK --interval=10s --timeout=3s --retries=3 CMD wget -qO- http://localhost:8081/health/live || exit 1
+CMD ["uvicorn", "apps.oracle-service.health_server:app", "--host", "0.0.0.0", "--port", "8081"]


### PR DESCRIPTION
This PR introduces CI infrastructure for building and publishing images to GHCR and adds production-grade Dockerfiles with healthchecks. It also includes a production docker-compose with Postgres, RabbitMQ, MinIO, core-service, and oracle-service, wired with health checks.\n\nHighlights\n- Dockerfiles\n  - apps/core-service/Dockerfile (multi-stage, pnpm workspace aware, HTTP healthcheck /health/live)\n  - apps/oracle-service/Dockerfile (uvicorn-fastapi health server, HTTP healthcheck /health/live)\n- GHCR Workflow\n  - .github/workflows/docker-publish.yml builds & pushes ghcr.io/<owner>/{core-service,oracle-service}:{sha,latest}\n  - Uses GITHUB_TOKEN for GHCR login; optional Doppler CLI install and connectivity verification\n- Docker Compose (prod)\n  - apps/docker-compose.prod.yml with Postgres, RabbitMQ, MinIO (+ mc bootstrap), core-service, oracle-service\n  - Readiness via health endpoints and service healthchecks\n- .dockerignore to keep contexts lean\n\nNotes\n- Doppler integration is optional in this PR (CLI presence + connectivity check). In a follow-up we will wire  into service entrypoints or GitHub Actions steps to inject env securely.\n- This PR does not change application runtime logic. It complements PR #1 Health & Observability Layer by enabling container builds and ship-ready probes.\n\nNext\n- PR #3 will wire Doppler secrets into workflows/compose and add environment matrices (dev/staging/prod) with GitHub OIDC/Doppler project-config mapping, plus CI gates for health smoke checks.\n