### PR TITLE
PR #3: Secrets Management with Doppler (CI + Compose + Docs)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Root dockerignore to keep build contexts small
+
+# VCS
+.git
+
+# Node
+node_modules/
+**/node_modules/
+**/*.tsbuildinfo
+apps/client/.next/
+
+# Python
+__pycache__/
+**/__pycache__/
+.venv/
+.venv-oracle/
+
+# Build outputs
+apps/core-service/dist/
+apps/core-service/coverage/
+apps/core-service/.env
+apps/core-service/prisma/*.db
+
+# Tests and local artifacts
+apps/core-service/test/
+apps/oracle-service/tests/

--- a/.github/workflows/production-ci.yml
+++ b/.github/workflows/production-ci.yml
@@ -1,0 +1,82 @@
+name: Production CI (GHCR + Doppler)
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Doppler CLI
+        uses: dopplerhq/cli-action@v7
+        with:
+          doppler-version: latest
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+
+      - name: Export secrets to env
+        run: |
+          doppler secrets download \
+            --no-file \
+            --format env \
+            --project ${{ vars.DOPPLER_PROJECT || 'studyapp' }} \
+            --config ${{ vars.DOPPLER_CONFIG || 'prod' }} >> $GITHUB_ENV
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+
+      - name: Derive image tags
+        id: meta
+        run: |
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          SHA=${{ github.sha }}
+          echo "core=ghcr.io/${OWNER}/core-service:${SHA}" >> $GITHUB_OUTPUT
+          echo "core_latest=ghcr.io/${OWNER}/core-service:latest" >> $GITHUB_OUTPUT
+          echo "oracle=ghcr.io/${OWNER}/oracle-service:${SHA}" >> $GITHUB_OUTPUT
+          echo "oracle_latest=ghcr.io/${OWNER}/oracle-service:latest" >> $GITHUB_OUTPUT
+
+      - name: Build & Push core-service
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/core-service/Dockerfile
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.core }}
+            ${{ steps.meta.outputs.core_latest }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build & Push oracle-service
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/oracle-service/Dockerfile
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.oracle }}
+            ${{ steps.meta.outputs.oracle_latest }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.doppler/
 
 # IDE
 .vscode/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
 # Study App
+
+## Secrets Management (Doppler)
+
+This repository uses Doppler as the single source of truth for all secrets (DATABASE_URL, JWT_SECRET, INTERNAL_API_KEY, etc.). No `.env` files are required or supported for production workflows.
+
+### Install and Authenticate (Local)
+
+```bash
+brew install dopplerhq/cli/doppler
+doppler login
+# (optional) set defaults for this repo
+doppler configure set project studyapp
+doppler configure set config dev
+```
+
+### Run Services with Doppler (Local Dev)
+
+Core-service (NestJS):
+
+```bash
+doppler run -- pnpm -F core-service start:dev
+```
+
+Oracle-service (FastAPI health server):
+
+```bash
+doppler run -- uvicorn apps.oracle-service.health_server:app --host 0.0.0.0 --port 8081
+```
+
+### Prod-like Stack (Docker Compose)
+
+Use Doppler to inject secrets into Docker Compose:
+
+```bash
+DOPPLER_PROJECT=studyapp DOPPLER_CONFIG=prod \
+  doppler run -- docker compose -f apps/docker-compose.prod.yml up -d
+```
+
+This will launch Postgres, RabbitMQ, MinIO, `core-service`, and `oracle-service`. Health checks are wired to `/health/live` and `/health/ready` endpoints.
+
+### CI/CD
+
+GitHub Actions integrates with Doppler using the official CLI action. Secrets are exported as environment variables for build jobs. Images are built and pushed to GHCR; no secrets are embedded into images.

--- a/apps/core-service/README.md
+++ b/apps/core-service/README.md
@@ -57,28 +57,32 @@ $ pnpm run test:e2e
 $ pnpm run test:cov
 ```
 
-## Environment Variables
+## Secrets & Local Development (Doppler)
 
-Set the following variables (e.g., in `.env`) for local development. CI will inject required secrets as needed.
+This service uses Doppler as the single source of truth for secrets. Do not use `.env` files.
+
+### One-time setup
 
 ```bash
-# Core
-DATABASE_URL="file:./prisma/dev.db"  # SQLite local dev
-JWT_SECRET=your-jwt-secret
-
-# S3
-AWS_REGION=your-aws-region
-AWS_S3_BUCKET=your-bucket-name
-# Optional for S3-compatible endpoints (e.g., MinIO)
-AWS_S3_ENDPOINT=http://localhost:9000
-AWS_S3_FORCE_PATH_STYLE=true
-
-# RabbitMQ
-RABBITMQ_URL=amqp://localhost:5672
-
-# Internal API key for oracle callback
-INTERNAL_API_KEY=dev-internal-key
+brew install dopplerhq/cli/doppler
+doppler login
+doppler configure set project studyapp
+doppler configure set config dev
 ```
+
+### Run in development
+
+```bash
+doppler run -- pnpm start:dev
+```
+
+Common secrets managed in Doppler:
+
+- `DATABASE_URL` (SQLite for dev, Postgres for prod)
+- `JWT_SECRET`
+- `RABBITMQ_URL`
+- `AWS_REGION`, `AWS_S3_BUCKET`, `AWS_S3_ENDPOINT`, `AWS_S3_FORCE_PATH_STYLE`
+- `INTERNAL_API_KEY`
 
 ## Health Endpoints
 

--- a/apps/docker-compose.prod.yml
+++ b/apps/docker-compose.prod.yml
@@ -1,0 +1,114 @@
+version: "3.9"
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  rabbitmq:
+    image: rabbitmq:3-management-alpine
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "status"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  minio:
+    image: quay.io/minio/minio:latest
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  minio-mc:
+    image: minio/mc:latest
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: ["/bin/sh", "-c"]
+    command: >
+      "mc alias set local http://minio:9000 ${MINIO_ROOT_USER:-minioadmin} ${MINIO_ROOT_PASSWORD:-minioadmin} &&
+      mc mb -p local/${AWS_S3_BUCKET} || true &&
+      mc anonymous set download local/${AWS_S3_BUCKET} || true"
+
+  core-service:
+    image: ghcr.io/${GHCR_OWNER:-your-org}/core-service:latest
+    depends_on:
+      postgres:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      JWT_SECRET: ${JWT_SECRET}
+      INTERNAL_API_KEY: ${INTERNAL_API_KEY}
+      RABBITMQ_URL: ${RABBITMQ_URL}
+      AWS_REGION: ${AWS_REGION}
+      AWS_S3_BUCKET: ${AWS_S3_BUCKET}
+      AWS_S3_ENDPOINT: ${AWS_S3_ENDPOINT}
+      AWS_S3_FORCE_PATH_STYLE: ${AWS_S3_FORCE_PATH_STYLE}
+    ports:
+      - "3000:3000"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/health/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  oracle-service:
+    image: ghcr.io/${GHCR_OWNER:-your-org}/oracle-service:latest
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+      core-service:
+        condition: service_started
+    environment:
+      RABBITMQ_URL: ${RABBITMQ_URL}
+      RABBITMQ_QUEUE_NAME: ${RABBITMQ_QUEUE_NAME}
+      CORE_SERVICE_URL: ${CORE_SERVICE_URL}
+      INTERNAL_API_KEY: ${INTERNAL_API_KEY}
+      AWS_REGION: ${AWS_REGION}
+      S3_BUCKET: ${S3_BUCKET}
+      AWS_S3_ENDPOINT: ${AWS_S3_ENDPOINT}
+      AWS_S3_FORCE_PATH_STYLE: ${AWS_S3_FORCE_PATH_STYLE}
+      ENGINE_VERSION: ${ENGINE_VERSION}
+    ports:
+      - "8081:8081"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8081/health/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  pgdata:
+  minio-data:

--- a/apps/oracle-service/README.md
+++ b/apps/oracle-service/README.md
@@ -1,0 +1,49 @@
+# Oracle Service — Health & Worker Runtime
+
+This service exposes a lightweight FastAPI health server and (in full runtime) a document processing worker. Secrets are provided by Doppler.
+
+## Secrets Management (Doppler)
+
+Do not use `.env` files. Use Doppler for all environments.
+
+### One-time setup (local)
+
+```bash
+brew install dopplerhq/cli/doppler
+doppler login
+# Optional defaults
+doppler configure set project studyapp
+doppler configure set config dev
+```
+
+### Run health server locally
+
+```bash
+doppler run -- uvicorn apps.oracle-service.health_server:app --host 0.0.0.0 --port 8081
+```
+
+### Common secrets (managed in Doppler)
+
+- `RABBITMQ_URL` (e.g., amqp://guest:guest@localhost:5672//)
+- `RABBITMQ_QUEUE_NAME` (e.g., document_processing_jobs)
+- `CORE_SERVICE_URL` (http://localhost:3000 for local; http://core-service:3000 in containers)
+- `INTERNAL_API_KEY` (must match core-service)
+- `AWS_REGION`
+- `S3_BUCKET`
+- `AWS_S3_ENDPOINT` (e.g., http://localhost:9000 for MinIO)
+- `AWS_S3_FORCE_PATH_STYLE` ("true" for MinIO)
+- `ENGINE_VERSION` (e.g., oracle-v1)
+
+### Compose (prod-like)
+
+Secrets are injected by Doppler at runtime.
+
+```bash
+DOPPLER_PROJECT=studyapp DOPPLER_CONFIG=prod \
+  doppler run -- docker compose -f apps/docker-compose.prod.yml up -d
+```
+
+This launches Postgres, RabbitMQ, MinIO, core-service, and oracle-service. Health endpoints:
+
+- core-service: `GET /health/live`, `GET /health/ready`
+- oracle-service: `GET /health/live`, `GET /health/ready`

--- a/doppler.yaml
+++ b/doppler.yaml
@@ -1,0 +1,14 @@
+# doppler.yaml
+# Centralized Doppler project/config defaults for this repo. Safe to commit.
+
+setup:
+  project: studyapp
+  config: dev
+
+environments:
+  dev:
+    config: dev
+  staging:
+    config: staging
+  prod:
+    config: prod


### PR DESCRIPTION
This PR integrates Doppler as the single source of truth for secrets across environments.\n\nWhat’s included\n- doppler.yaml: repo-level defaults for project/config.\n- .gitignore: ignore .doppler/ metadata.\n- .dockerignore: reduce Docker build contexts.\n- .github/workflows/production-ci.yml: CI pipeline uses dopplerhq/cli-action@v7 to fetch secrets and export to env, then builds/pushes GHCR images.\n- apps/docker-compose.prod.yml: refactored to environment-variable driven; intended to run via `doppler run -- docker compose ...`.\n- apps/core-service/README.md: replaced .env guidance with Doppler-based workflow.\n- apps/oracle-service/README.md: new; documents Doppler secrets and local run.\n- README.md (root): centralized Doppler instructions and stack run examples.\n\nHow to run locally\n- Install Doppler CLI and login.\n- doppler run -- pnpm -F core-service start:dev\n- doppler run -- uvicorn apps.oracle-service.health_server:app --host 0.0.0.0 --port 8081\n- DOPPLER_PROJECT=studyapp DOPPLER_CONFIG=prod doppler run -- docker compose -f apps/docker-compose.prod.yml up -d\n\nSecurity posture\n- No .env files in production workflow.\n- Secrets are injected at runtime; not embedded into container images.\n\nAcceptance criteria\n- CI builds pass; GHCR images published.\n- Documentation reflects Doppler-only secret management.\n- Compose stack starts correctly with doppler run.\n